### PR TITLE
Change path separator to make the firmeware project compilable on mac

### DIFF
--- a/doc/knx-dev-setup.md
+++ b/doc/knx-dev-setup.md
@@ -44,13 +44,13 @@ You should be now in a directory ending with ...\Documents\PlatformIO\Projects
     git clone https://github.com/mumpf/knx-sensor.git
     cd knx
     git checkout release
-    cd ..\knx-common
+    cd ../knx-common
     git checkout release
-    cd ..\knx-logic
+    cd ../knx-logic
     git checkout release
-    cd ..\knx-wire
+    cd ../knx-wire
     git checkout release
-    cd ..\knx-sensor
+    cd ../knx-sensor
     git checkout release
     code Sensormodul.code-workspace
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ build_flags =
 monitor_speed = 115200
 lib_ldf_mode = deep+
 lib_extra_dirs = 
-  ${PROJECT_DIR}\..
+  ${PROJECT_DIR}/..
 lib_deps = 
   SPI
   Wire


### PR DESCRIPTION
Thank you @mumpf  for this project!

This PR makes the sensor firmware project compilable on mac and linux systems by changing the path separator to / which is also fine for windows. 
Unfortunately, I do not know how the knx-dev-setup.pdf setup is created out of the .md file. But it should be also updated.